### PR TITLE
Remove bevy version from cargo when using main branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false }
 spin_sleep = "1.0"
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", version = "0.5", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
     "render",
     "bevy_winit",
     "x11",


### PR DESCRIPTION
Heyo, awesome work on this, just noticed that specifying the version broke a bit when updating to bevy 0.6. Alternatively I could just set this to 0.6, but since the branch is being used anyways I think removing it is fine.

I could also just change this to specify the version to just 0.6 if you want and could have a separate branch of `bevy_main` similar to a lot of other repos.