### PR TITLE
Switch to custom bevy diagnostics, remove spin_sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-fe
     "bevy_render",
     "bevy_winit",
 ] }
-spin_sleep = "1.0"
 
 [features]
 default = ["x11"]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, render::camera::Projection};
+use bevy::{diagnostic::LogDiagnosticsPlugin, prelude::*, render::camera::Projection};
 use bevy_framepace::{FramepacePlugin, FramepaceSettings, Limiter};
 use bevy_mod_picking::{
     DebugCursorPickingPlugin, PickableBundle, PickingCameraBundle, PickingPlugin,
@@ -7,13 +7,8 @@ use bevy_mod_picking::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // Add the framepacing plugin.
+        // Add the framepacing plugin
         .add_plugin(FramepacePlugin)
-        // Frame drop  warning can be disabled by uncommenting this line, but we will keep them on
-        // for the demo:
-        //
-        // .insert_resource(FramepaceSettings::default().with_warnings(false))
-        //
         // Our systems for this demo
         .add_startup_system(setup)
         .add_system(toggle_plugin)
@@ -21,6 +16,8 @@ fn main() {
         // Mouse picking to visualize latency
         .add_plugin(PickingPlugin)
         .add_plugin(DebugCursorPickingPlugin)
+        // Log framepace custom bevy diagnostics to stdout
+        .add_plugin(LogDiagnosticsPlugin::default())
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,17 @@
 #![deny(missing_docs)]
 
 use bevy::{
+    diagnostic::{Diagnostic, DiagnosticId, Diagnostics},
     prelude::*,
     render::{Extract, RenderApp, RenderStage},
+    utils::Instant,
     winit::WinitWindows,
 };
-use std::time::{Duration, Instant};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 /// Adds framepacing and framelimiting functionality to your [`App`].
 #[derive(Debug, Clone, Component)]
@@ -43,10 +49,12 @@ impl Plugin for FramepacePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FramepaceSettings>()
             .init_resource::<FrametimeLimit>()
-            .add_system_to_stage(CoreStage::Update, get_display_refresh_rate);
+            .init_resource::<FramePaceStats>()
+            .add_system_to_stage(CoreStage::Update, get_display_refresh_rate)
+            .add_plugin(FramePaceDiagnosticsPlugin);
         app.sub_app_mut(RenderApp)
             .insert_resource(FrameTimer::default())
-            .add_system_to_stage(RenderStage::Extract, extract_display_refresh_rate)
+            .add_system_to_stage(RenderStage::Extract, extract_resources)
             .add_system_to_stage(
                 RenderStage::Cleanup,
                 // We need this system to run at the end, immediately before the event loop restarts
@@ -60,17 +68,8 @@ impl Plugin for FramepacePlugin {
 pub struct FramepaceSettings {
     /// Configures the framerate limiting strategy.
     pub limiter: Limiter,
-    /// When enabled, the plugin logs a warning every time the app's frametime exceeds the target
-    /// frametime by 100µs.
-    pub warn_on_frame_drop: bool,
 }
 impl FramepaceSettings {
-    /// Builds plugin settings with warnings set to `warnings_enabled`.
-    pub fn with_warnings(mut self, warnings_enabled: bool) -> Self {
-        self.warn_on_frame_drop = warnings_enabled;
-        self
-    }
-
     /// Builds plugin settings with the specified [`Limiter`] configuration.
     pub fn with_limiter(mut self, limiter: Limiter) -> Self {
         self.limiter = limiter;
@@ -81,7 +80,6 @@ impl Default for FramepaceSettings {
     fn default() -> FramepaceSettings {
         FramepaceSettings {
             limiter: Limiter::Auto,
-            warn_on_frame_drop: true,
         }
     }
 }
@@ -165,50 +163,114 @@ fn detect_frametime(winit: NonSend<WinitWindows>, windows: Res<Windows>) -> Opti
     Some(best_frametime)
 }
 
-fn extract_display_refresh_rate(
+fn extract_resources(
     mut commands: Commands,
     settings: Extract<Res<FramepaceSettings>>,
     framerate_limit: Extract<Res<FrametimeLimit>>,
+    stats: Extract<Res<FramePaceStats>>,
 ) {
     commands.insert_resource(settings.to_owned());
     commands.insert_resource(framerate_limit.to_owned());
+    commands.insert_resource(stats.to_owned());
+}
+
+/// Holds frame time measurements for framepacing diagnostics
+#[derive(Clone, Debug, Resource)]
+pub struct FramePaceStats {
+    oversleep: Arc<Mutex<VecDeque<Duration>>>,
+    frametime: Arc<Mutex<Duration>>,
+}
+
+impl Default for FramePaceStats {
+    fn default() -> Self {
+        Self {
+            oversleep: Arc::new(Mutex::new(VecDeque::from([Duration::ZERO; 240]))),
+            frametime: Default::default(),
+        }
+    }
 }
 
 fn framerate_limiter(
     mut timer: ResMut<FrameTimer>,
     settings: Res<FramepaceSettings>,
     target_frametime: Res<FrametimeLimit>,
+    stats: Res<FramePaceStats>,
 ) {
     let target_frametime = target_frametime.0;
-    let this_render_time = Instant::now().duration_since(timer.render_end);
-    let sleep_needed = target_frametime.saturating_sub(this_render_time);
+    let system_start = Instant::now();
+    let this_render_time = system_start.duration_since(timer.render_end);
 
-    if settings.limiter.is_enabled() {
-        spin_sleep::sleep(sleep_needed);
+    let mut last_oversleep_lock = stats.oversleep.try_lock().unwrap();
+    let last_oversleep_avg =
+        last_oversleep_lock.iter().sum::<Duration>() / last_oversleep_lock.len() as u32;
+
+    let sleep_needed = target_frametime.saturating_sub(this_render_time);
+    let sleep_needed_coarse = sleep_needed.saturating_sub(last_oversleep_avg * 2);
+
+    let sleep_start = Instant::now();
+    if settings.limiter.is_enabled() && sleep_needed_coarse > Duration::ZERO {
+        std::thread::sleep(sleep_needed_coarse);
     }
 
-    frametime_alert(
-        Instant::now().duration_since(timer.render_end),
-        target_frametime,
-        &settings,
-    );
+    let this_oversleep = Instant::now()
+        .duration_since(sleep_start)
+        .saturating_sub(sleep_needed_coarse);
+
+    if settings.limiter.is_enabled() {
+        while Instant::now().duration_since(system_start) < sleep_needed {}
+    }
+
+    last_oversleep_lock.pop_back();
+    last_oversleep_lock.push_front(this_oversleep);
+
+    *stats.frametime.try_lock().unwrap() = Instant::now().duration_since(timer.render_end);
 
     timer.render_end = Instant::now();
 }
 
-fn frametime_alert(
-    this_frametime: Duration,
-    target_frametime: Duration,
-    settings: &Res<FramepaceSettings>,
-) {
-    if this_frametime.saturating_sub(target_frametime) > Duration::from_micros(100)
-        && settings.warn_on_frame_drop
-        && settings.limiter.is_enabled()
-    {
-        warn!(
-            "[Frame Drop] {:.2?} (+{:.2?})",
-            this_frametime,
-            this_frametime.saturating_sub(target_frametime),
-        );
+/// Adds [`Diagnostics`] data from `bevy_framepace`
+pub struct FramePaceDiagnosticsPlugin;
+
+impl Plugin for FramePaceDiagnosticsPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_startup_system(Self::setup_system)
+            .add_system(Self::diagnostic_system);
+    }
+}
+
+impl FramePaceDiagnosticsPlugin {
+    /// [`DiagnosticId`] for the frametime
+    pub const FRAMEPACE_FRAMETIME: DiagnosticId =
+        DiagnosticId::from_u128(8021378406439507683279787892187089153);
+    /// [`DiagnosticId`] for oversleep
+    pub const FRAMEPACE_OVERSLEEP: DiagnosticId =
+        DiagnosticId::from_u128(7873478903246724896826890280382389054);
+
+    /// Initial setup for framepace diagnostics
+    pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
+        diagnostics
+            .add(Diagnostic::new(Self::FRAMEPACE_FRAMETIME, "fp_frametime", 20).with_suffix("ms"));
+        diagnostics
+            .add(Diagnostic::new(Self::FRAMEPACE_OVERSLEEP, "fp_oversleep", 20).with_suffix("µs"));
+    }
+
+    /// Updates diagnostic data from measurements
+    pub fn diagnostic_system(
+        mut diagnostics: ResMut<Diagnostics>,
+        time: Res<Time>,
+        stats: Res<FramePaceStats>,
+    ) {
+        if time.delta_seconds_f64() == 0.0 {
+            return;
+        }
+
+        let frametime_millis = stats.frametime.lock().unwrap().as_secs_f64() * 1000.0;
+        let oversleep_lock = stats.oversleep.lock().unwrap();
+        let oversleep_micros =
+            (oversleep_lock.iter().sum::<Duration>() / oversleep_lock.len() as u32).as_secs_f64()
+                * 1000000.0;
+
+        diagnostics.add_measurement(Self::FRAMEPACE_FRAMETIME, || frametime_millis);
+        diagnostics.add_measurement(Self::FRAMEPACE_OVERSLEEP, || oversleep_micros);
     }
 }


### PR DESCRIPTION
- Removes the `spin_sleep` dependency, closing #3.
- Auto-detects sleep inaccuracy at runtime to determine how long to sleep, and how long to spin for accurate sleep timing on the user's system.
- Moves diagnostics to bevy's built in diagnostics, reducing log spam.