### PR TITLE
Don't print unless `framepace_debug` feature is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,6 +203,7 @@ fn get_display_refresh_rate(
         },
         Limiter::Manual(frametime) => frametime,
         Limiter::Off => {
+            #[cfg(feature = "framepace_debug")]
             info!("Frame limiter disabled");
             return;
         }
@@ -210,6 +211,7 @@ fn get_display_refresh_rate(
 
     if let Ok(mut limit) = frame_limit.0.try_lock() {
         if new_frametime != *limit {
+            #[cfg(feature = "framepace_debug")]
             info!("Frametime limit changed to: {:?}", new_frametime);
             *limit = new_frametime;
         }


### PR DESCRIPTION
I don't like the print spam, I thought disabling the `framepace_debug` would make them go away but they didn't.

`Frame limiter disabled` is spammed very quickly when the fps cap is off :/

It makes sense that these debug prints would go away when this feature is disabled, so I implemented that.