### PR TITLE
Change add_plugin to add_plugins in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 It's as simple as adding the plugin to your app:
 
 ```rs
-app.add_plugin(bevy_framepace::FramepacePlugin);
+app.add_plugins(bevy_framepace::FramepacePlugin);
 ```
 
 By default, the plugin will automatically measure your framerate and use this for framepacing.


### PR DESCRIPTION
add_plugin gives a deprecated warning as of Bevy 0.11

Thanks for making this crate, just started using it but seems extremely useful!