### PR TITLE
Add wasm32 workaround for missing `pipelined_rendering`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,12 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_reflect::prelude::*;
-use bevy_render::{pipelined_rendering::RenderExtractApp, Render, RenderApp, RenderSet};
+use bevy_render::{Render, RenderApp, RenderSet};
 use bevy_utils::Instant;
 use bevy_window::prelude::*;
 
+#[cfg(not(target_arch = "wasm32"))]
+use bevy_render::pipelined_rendering::RenderExtractApp;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_winit::WinitWindows;
 
@@ -44,6 +46,11 @@ use std::{
 
 #[cfg(feature = "framepace_debug")]
 pub mod debug;
+
+/// A dummy label for the subapp of the rendered pipeline that does not exist in wasm32
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, bevy_app::AppLabel)]
+struct RenderExtractApp;
 
 /// Adds framepacing and framelimiting functionality to your [`App`].
 #[derive(Debug, Clone, Component)]


### PR DESCRIPTION
The `pipelined_rendering` export is no longer available in Bevy since version 0.12 in wasm32 builds; it can no longer be used to select the right subapp.

Add a dummy version of the `AppLabel` that targets the `pipelined_rendering` subapp. Using a dummy app label allows to keep the same code to get the right subapp to apply the framepace resources and systems.

Fixes #54.