### PR TITLE
add bevy 0.15 version to readme table

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_framepace            |
 | ---- | -------------------       |
+| 0.15 | 0.18                      |
 | 0.14 | 0.17                      |
 | 0.13 | 0.15, 0.16                |
 | 0.12 | 0.14                      |


### PR DESCRIPTION
simple oversight which may confuse ppl reading readme

(at some point might make sense to push a patch version so crates.io is also updated)