### PR TITLE
Bump to Bevy 0.17.0 RC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ documentation = "https://docs.rs/bevy_framepace"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.16.0", default-features = false }
-bevy_ecs = { version = "0.16.0", default-features = false }
-bevy_diagnostic = { version = "0.16.0", default-features = false }
-bevy_log = { version = "0.16.0", default-features = false }
-bevy_render = { version = "0.16.0", default-features = false }
-bevy_reflect = { version = "0.16.0", default-features = false }
-bevy_time = { version = "0.16.0", default-features = false }
-bevy_platform = { version = "0.16.0", default-features = false }
-bevy_window = { version = "0.16.0", default-features = false }
-bevy_winit = { version = "0.16.0", default-features = false }
+bevy_app = { version = "0.17.0-rc", default-features = false }
+bevy_ecs = { version = "0.17.0-rc", default-features = false }
+bevy_diagnostic = { version = "0.17.0-rc", default-features = false }
+bevy_log = { version = "0.17.0-rc", default-features = false }
+bevy_render = { version = "0.17.0-rc", default-features = false }
+bevy_reflect = { version = "0.17.0-rc", default-features = false }
+bevy_time = { version = "0.17.0-rc", default-features = false }
+bevy_platform = { version = "0.17.0-rc", default-features = false }
+bevy_window = { version = "0.17.0-rc", default-features = false }
+bevy_winit = { version = "0.17.0-rc", default-features = false }
 # Non-bevy
 spin_sleep = "1.0"
 
@@ -33,9 +33,9 @@ default = ["framepace_debug"]
 framepace_debug = []
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc.3", default-features = false, features = [
+bevy = { version = "0.17.0-rc", default-features = false, features = [
     "bevy_color",
-    "bevy_ui",
+    "bevy_ui_render",
     "bevy_gizmos",
     "bevy_winit",
     "bevy_window",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_framepace"
-version = "0.19.1"
+version = "0.20.0-rc.1"
 edition = "2024"
 resolver = "2"
 description = "Frame pacing and frame limiting for Bevy"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_framepace            |
 | ---- | -------------------       |
+| 0.17.0-rc | 0.20.0-rc                      |
 | 0.16 | 0.19                      |
 | 0.15 | 0.18                      |
 | 0.14 | 0.17                      |

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,5 @@
 use bevy::{color::palettes, prelude::*};
-use bevy_window::{SystemCursorIcon, Window};
-use bevy_winit::cursor::CursorIcon;
+use bevy_window::{CursorIcon, SystemCursorIcon, Window};
 
 fn main() {
     App::new()


### PR DESCRIPTION
Note: the default for Bevy 0.17 on Linux is now wayland and not X11. Since this crate doesn't use any default features and explicitly selects x11 for the examples and the CI, I left it at that. Just mentioning :)