### PR TITLE
Fix Limiter::Auto not working with bevy 0.17.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ use bevy_reflect::prelude::*;
 use bevy_render::{Render, RenderApp, RenderSystems};
 
 #[cfg(not(target_arch = "wasm32"))]
+use bevy_ecs::system::NonSendMarker;
+#[cfg(not(target_arch = "wasm32"))]
 use bevy_window::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_winit::WINIT_WINDOWS;
@@ -182,7 +184,7 @@ fn get_display_refresh_rate(
     settings: Res<FramepaceSettings>,
     windows: Query<Entity, With<Window>>,
     frame_limit: Res<FrametimeLimit>,
-    _token: Option<NonSend<()>>, // The NonSend token ensures that this system runs on the Bevy main thread.
+    _non_send_marker: NonSendMarker, // This system may call WINIT_WINDOWS.with_borrow indirectly which requires the system runs on the Bevy main thread.
 ) {
     let new_frametime = match settings.limiter {
         Limiter::Auto => match detect_frametime(windows.iter()) {


### PR DESCRIPTION
As described in https://github.com/aevyrie/bevy_framepace/issues/69, WINIT_WINDOWS.with_borrow must be called from the bevy main thread.