### PR TITLE
Update to Bevy 0.19, bump to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.22.0 - 2026-07-16
+
+- Bumped to Bevy 0.19
+
 # 0.20.1 - 2025-12-08
 
 - Fix non-send usage of winit.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_framepace"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 resolver = "2"
 description = "Frame pacing and frame limiting for Bevy"
@@ -11,16 +11,16 @@ documentation = "https://docs.rs/bevy_framepace"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy_app = { version = "0.18", default-features = false }
-bevy_ecs = { version = "0.18", default-features = false }
-bevy_diagnostic = { version = "0.18", default-features = false }
-bevy_log = { version = "0.18", default-features = false }
-bevy_render = { version = "0.18", default-features = false }
-bevy_reflect = { version = "0.18", default-features = false }
-bevy_time = { version = "0.18", default-features = false }
-bevy_platform = { version = "0.18", default-features = false }
-bevy_window = { version = "0.18", default-features = false }
-bevy_winit = { version = "0.18", default-features = false }
+bevy_app = { version = "0.19", default-features = false }
+bevy_ecs = { version = "0.19", default-features = false }
+bevy_diagnostic = { version = "0.19", default-features = false }
+bevy_log = { version = "0.19", default-features = false }
+bevy_render = { version = "0.19", default-features = false }
+bevy_reflect = { version = "0.19", default-features = false }
+bevy_time = { version = "0.19", default-features = false }
+bevy_platform = { version = "0.19", default-features = false }
+bevy_window = { version = "0.19", default-features = false }
+bevy_winit = { version = "0.19", default-features = false }
 # Non-bevy
 spin_sleep = "1.0"
 
@@ -33,7 +33,7 @@ default = ["framepace_debug"]
 framepace_debug = []
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_color",
     "bevy_ui_render",
     "bevy_gizmos",

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_framepace            |
 |------|---------------------------|
+| 0.19 | 0.22                      |
 | 0.18 | 0.21                      |
 | 0.17 | 0.20                      |
 | 0.16 | 0.19                      |

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, window: Single<Entity, With<Window>>) {
 
     // UI
     let text_font = TextFont {
-        font_size: 50.,
+        font_size: FontSize::Px(50.0),
         ..default()
     };
     commands


### PR DESCRIPTION
## Summary
- Bump all `bevy_*` deps and the dev `bevy` dep to `0.19`
- Bump crate version `0.21.0` → `0.22.0`
- Use `FontSize::Px(50.0)` in the `demo` example (Bevy 0.19 changed `TextFont::font_size` from `f32` to `FontSize`)
- Add `0.22.0` entry to `CHANGELOG.md`
- Add `0.19 | 0.22` row to the compatibility table in `README.md`

## Test plan
- [x] `cargo build --lib --features "bevy_winit/x11"`
- [x] `cargo build --examples --features "bevy_winit/x11"`
- [x] `cargo clippy --lib --features "bevy_winit/x11" -- -D warnings`

Closes #77, closes #78.